### PR TITLE
BUGFIX: Fixed permissions error when attempting write to /app/memory.json

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,9 +9,13 @@ services:
       context: ./servers/memory
     ports:
       - 8082:8000
+    volumes:
+      - memory:/app/data:rw
   time-server:
     build:
       context: ./servers/time
     ports:
       - 8083:8000
 
+volumes:
+  memory:

--- a/servers/memory/Dockerfile
+++ b/servers/memory/Dockerfile
@@ -38,8 +38,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=requirements.txt \
     python -m pip install -r requirements.txt
 
-# Change the ownership of /app directory and its contents to appuser
-RUN chown -R ${UID}:${UID} /app
+# Change the ownership of /app/data directory and its contents to appuser
+RUN mkdir -p /app/data && touch /app/data/memory.json && chown -R ${UID}:${UID} /app/data
+
+# Set a flag for the location of the database
+ENV MEMORY_FILE_PATH="/app/data/memory.json"
 
 # Switch to the non-privileged user to run the application.
 USER appuser

--- a/servers/memory/Dockerfile
+++ b/servers/memory/Dockerfile
@@ -38,6 +38,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=requirements.txt \
     python -m pip install -r requirements.txt
 
+# Change the ownership of /app directory and its contents to appuser
+RUN chown -R ${UID}:${UID} /app
+
 # Switch to the non-privileged user to run the application.
 USER appuser
 

--- a/servers/memory/compose.yaml
+++ b/servers/memory/compose.yaml
@@ -4,4 +4,9 @@ services:
       context: .
     ports:
       - 8000:8000
+    volumes:
+      - memory:/app/data:rw
+
+volumes:
+  memory:
 


### PR DESCRIPTION
When running as a docker container, the following error used to occur from the Python script:

```bash
PermissionError: [Errno 13] Permission denied: '/app/memory.json'
```

To resolve this, I moved `memory.json` to the `/app/data` folder, changed the ownership to `appuser` using the `UID` variable, and set the `MEMORY_FILE_PATH` env variable. Now, the error no longer occurs. I also made this folder a volume for data persistence as a QoL improvement. Something similar may be desirable for the filesystem server, but I don't use that server and just didn't work on it. :upside_down_face: