### PR TITLE
feat: Implement delete confirmation system, general filesystem operation improvements

### DIFF
--- a/servers/filesystem/config.py
+++ b/servers/filesystem/config.py
@@ -3,5 +3,5 @@ import pathlib
 
 # Constants
 ALLOWED_DIRECTORIES = [
-    str(pathlib.Path(os.path.expanduser("~/")).resolve())
+    str(pathlib.Path(os.path.expanduser("~/tmp")).resolve())
 ]  # 👈 Replace with your paths

--- a/servers/filesystem/config.py
+++ b/servers/filesystem/config.py
@@ -1,0 +1,7 @@
+import os
+import pathlib
+
+# Constants
+ALLOWED_DIRECTORIES = [
+    str(pathlib.Path(os.path.expanduser("~/")).resolve())
+]  # 👈 Replace with your paths

--- a/servers/filesystem/main.py
+++ b/servers/filesystem/main.py
@@ -11,10 +11,11 @@ from typing import List, Optional, Literal
 import difflib
 import shutil
 from datetime import datetime, timezone
-from .config import ALLOWED_DIRECTORIES
+from config import ALLOWED_DIRECTORIES
+
 app = FastAPI(
     title="Secure Filesystem API",
-    version="0.1.0",
+    version="0.1.1",
     description="A secure file manipulation server for reading, editing, writing, listing, and searching files with access restrictions.",
 )
 

--- a/servers/filesystem/main.py
+++ b/servers/filesystem/main.py
@@ -12,7 +12,7 @@ import difflib
 import shutil
 from datetime import datetime, timezone, timedelta
 import uuid
-from .config import ALLOWED_DIRECTORIES
+from config import ALLOWED_DIRECTORIES
 app = FastAPI(
     title="Secure Filesystem API",
     version="0.1.0",


### PR DESCRIPTION
## Enhance delete_path endpoint with two-step confirmation

### Summary
This PR improves the security of the /delete_path endpoint by introducing a two-step delete confirmation process using ephemeral confirmation tokens. My main goal here @tjbck was to ensure that hallucinations or runaway LLMs don't inadvertently go blowing away parts of a user's filesystem. 

### Major Changes

- ✳️ Introduced a two-step confirmation mechanism for file/directory deletion:
  - First request returns a confirmation token and expiry timestamp.
  - Second request (with token) confirms and executes deletion.
- New response model: ConfirmationRequiredResponse.
- Updated DeletePathRequest model to replace confirm_delete with confirmation_token.
- Persistence logic:
  - Pending confirmation tokens are stored in .pending_confirmations.json.
  - Expired or mismatched requests are safely rejected.
- Token expires after 60 seconds.
  
### Additional Improvements

- 🔄 Moved ALLOWED_DIRECTORIES config into a new config.py file.
- 🧼 Removed unused print/debug statements.
- ⚙️ Minor imports and dependency updates for clarity (e.g. uuid, json, Union).

### Version
Bumped API version from 0.1.0 → 0.1.1.

---
✅ Safe for review and merge.

Screenshot:
<img width="1530" alt="Screenshot 2025-04-17 at 11 43 54 AM" src="https://github.com/user-attachments/assets/c6d484f1-1ae0-4c4e-a755-d9ef2f28739f" />